### PR TITLE
replace beat.position(deprecated) to beat.number.

### DIFF
--- a/viz.js
+++ b/viz.js
@@ -86,7 +86,7 @@ window.setBeatEvent = function(){
 	player.on( "beatEnter", function(e){
 		for(var i=1; i<=4; i++ ) {
 			li = $("#beats li.b" + i )
-			if (e.data.beat.position == i) {
+			if (e.data.beat.number == i) {
 				li.addClass("current");
 			} else {
 				li.removeClass("current");


### PR DESCRIPTION
beat.positionが非推奨になっており、動かすと下記の警告が出るので、beat.numberに変えました。

`[Songle API warn] 'position' is legacy API, please use 'number'{	"index": 13,	"startTimeMs": 12531,	"startTimeSec": 12.5317,	"numberOfBeatsPerBar": 4,	"number": 2,	"bpm": 121}`